### PR TITLE
Generalizing description of SG and adding links to Monarch and SciCrunch

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ SciGraph
 [![Build Status](https://travis-ci.org/SciCrunch/SciGraph.svg?branch=master)](https://travis-ci.org/SciCrunch/SciGraph)
 [![Coverage Status](https://coveralls.io/repos/SciCrunch/SciGraph/badge.svg)](https://coveralls.io/r/SciCrunch/SciGraph)
 
-Represent ontologies in a Neo4j graph.
+Represent ontologies and ontology-encoded knowledge in a Neo4j graph.
 
 Motivation
 ----------
-SciGraph aims to represent ontologies as a Neo4j graph. SciGraph
+SciGraph aims to represent ontologies and data described using ontologies as a Neo4j graph. SciGraph
 reads ontologies with [owlapi](http://owlapi.sourceforge.net/) and ingests
 ontology formats available to owlapi (OWL, RDF, OBO, TTL, etc). 
 Have a look at [how SciGraph translates some simple ontologies](https://github.com/SciCrunch/SciGraph/wiki/Neo4jMapping).

--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ Alternatives
 * [owlapi](https://owlcs.github.io/owlapi/)
 * [jena tdb](https://jena.apache.org/documentation/tdb/)
 
+Applications
+------------
+ * the [Monarch Initiative](monarchinitiative.org/) uses SciGraph for both ontologies and biological data modeling
+ * [SciCrunch](http://scicrunch.org/) uses SciGraph for vocabulary and annotation services
+
 Getting Started
 ---------------
 A [Vagrant](https://www.vagrantup.com/) box is included if you don't want to modify your `localhost`. You can launch a provisioned box like this 


### PR DESCRIPTION
I attempted to make the description more general - SG is more than an ontology server

I would like to link to documentation on the monarch-specific instance but haven't had time, for now I just link to the main website

Added a link to SciCrunch. @aguptasd @jgrethe any more?