### PR TITLE
[#152] Relationships contain full IRIs, try to encode it to a CURIE

### DIFF
--- a/SciGraph-core/src/main/java/io/scigraph/internal/EvidenceAspect.java
+++ b/SciGraph-core/src/main/java/io/scigraph/internal/EvidenceAspect.java
@@ -36,6 +36,7 @@ import org.neo4j.graphdb.Transaction;
 import com.google.common.base.Function;
 import com.tinkerpop.blueprints.Graph;
 import com.tinkerpop.blueprints.Vertex;
+import org.prefixcommons.CurieUtil;
 
 /***
  * Add "evidence" to a graph
@@ -55,10 +56,12 @@ public class EvidenceAspect implements GraphAspect {
       RelationshipType.withName("http://purl.org/oban/association_has_predicate");
 
   private final GraphDatabaseService graphDb;
+  private final CurieUtil curieUtil;
 
   @Inject
-  EvidenceAspect(GraphDatabaseService graphDb) {
+  EvidenceAspect(GraphDatabaseService graphDb, CurieUtil curieUtil) {
     this.graphDb = graphDb;
+    this.curieUtil = curieUtil;
   }
 
   @Override
@@ -99,15 +102,16 @@ public class EvidenceAspect implements GraphAspect {
 
                 if (isEdgeInGraph) { // means that the relationship exists between the subject and
                                      // object
-                  TinkerGraphUtil.addEdge(graph, hasSubject);
-                  TinkerGraphUtil.addEdge(graph, hasObject);
+                  TinkerGraphUtil tgu = new TinkerGraphUtil(graph, curieUtil);
+                  tgu.addEdge(hasSubject);
+                  tgu.addEdge(hasObject);
                   for (Relationship evidence : association.getRelationships(EVIDENCE,
                       Direction.OUTGOING)) {
-                    TinkerGraphUtil.addEdge(graph, evidence);
+                    tgu.addEdge(evidence);
                   }
                   for (Relationship source : association.getRelationships(SOURCE,
                       Direction.OUTGOING)) {
-                    TinkerGraphUtil.addEdge(graph, source);
+                    tgu.addEdge(source);
                   }
                 }
               } else {

--- a/SciGraph-core/src/test/java/io/scigraph/internal/EvidenceAspectTest.java
+++ b/SciGraph-core/src/test/java/io/scigraph/internal/EvidenceAspectTest.java
@@ -62,13 +62,14 @@ public class EvidenceAspectTest extends GraphTestBase {
         subject1.createRelationshipTo(object3, RelationshipType.withName(relationName));
     association2.createRelationshipTo(relationNode, EvidenceAspect.HAS_PREDICATE);
 
-    TinkerGraphUtil.addNode(graph, subject1);
-    TinkerGraphUtil.addNode(graph, object1);
-    TinkerGraphUtil.addNode(graph, object2);
-    TinkerGraphUtil.addNode(graph, object3);
-    TinkerGraphUtil.addNode(graph, relationNode);
-    TinkerGraphUtil.addEdge(graph, rel);
-    aspect = new EvidenceAspect(graphDb);
+    TinkerGraphUtil tgu = new TinkerGraphUtil(graph, curieUtil);
+    tgu.addNode(subject1);
+    tgu.addNode(object1);
+    tgu.addNode(object2);
+    tgu.addNode(object3);
+    tgu.addNode(relationNode);
+    tgu.addEdge(rel);
+    aspect = new EvidenceAspect(graphDb, curieUtil);
   }
 
   @Test

--- a/SciGraph-core/src/test/java/io/scigraph/internal/GraphApiNeighborhoodTest.java
+++ b/SciGraph-core/src/test/java/io/scigraph/internal/GraphApiNeighborhoodTest.java
@@ -64,7 +64,7 @@ public class GraphApiNeighborhoodTest extends GraphTestBase {
     h.createRelationshipTo(j, OwlRelationships.RDFS_SUBCLASS_OF);
     g.createRelationshipTo(j, OwlRelationships.RDFS_SUBCLASS_OF);
     e.createRelationshipTo(b, fizz);
-    graphApi = new GraphApi(graphDb, cypherUtil);
+    graphApi = new GraphApi(graphDb, cypherUtil, curieUtil);
   }
 
   @Test

--- a/SciGraph-core/src/test/java/io/scigraph/internal/GraphApiTest.java
+++ b/SciGraph-core/src/test/java/io/scigraph/internal/GraphApiTest.java
@@ -49,7 +49,7 @@ public class GraphApiTest extends GraphTestBase {
     c = graphDb.createNode();
     b.createRelationshipTo(a, OwlRelationships.RDFS_SUBCLASS_OF);
     c.createRelationshipTo(b, OwlRelationships.OWL_EQUIVALENT_CLASS);
-    graphApi = new GraphApi(graphDb, cypherUtil);
+    graphApi = new GraphApi(graphDb, cypherUtil, curieUtil);
   }
 
   @Test

--- a/SciGraph-core/src/test/java/io/scigraph/owlapi/postprocessors/EdgeLabelerTest.java
+++ b/SciGraph-core/src/test/java/io/scigraph/owlapi/postprocessors/EdgeLabelerTest.java
@@ -89,14 +89,14 @@ public class EdgeLabelerTest extends GraphTestBase {
 
   @Test
   public void canBeTransformedToTinkerGraph() {
-    Graph tg = new TinkerGraph();
+    TinkerGraphUtil tgu = new TinkerGraphUtil(curieUtil);
     ResourceIterator<Node> nodes = graphDb.getAllNodes().iterator();
     while (nodes.hasNext()) {
-      TinkerGraphUtil.addElement(tg, nodes.next());
+      tgu.addElement(nodes.next());
     }
     ResourceIterator<Relationship> relationships = graphDb.getAllRelationships().iterator();
     while (relationships.hasNext()) {
-      TinkerGraphUtil.addElement(tg, relationships.next());
+      tgu.addElement(relationships.next());
     }
   }
 }

--- a/SciGraph-core/src/test/java/io/scigraph/util/GraphTestBase.java
+++ b/SciGraph-core/src/test/java/io/scigraph/util/GraphTestBase.java
@@ -47,6 +47,7 @@ public class GraphTestBase {
   protected static GraphDatabaseService graphDb;
   protected static CypherUtil cypherUtil;
   protected static Graph graph;
+  protected static CurieUtil curieUtil;
   static ConcurrentHashMap<String, Long> idMap = new ConcurrentHashMap<>();
 
   Transaction tx;
@@ -80,7 +81,8 @@ public class GraphTestBase {
             Concept.ACRONYM));
     Neo4jModule.setupAutoIndexing(graphDb, config);
     graph = new GraphTransactionalImpl(graphDb, idMap, new RelationshipMap());
-    cypherUtil = new CypherUtil(graphDb, new CurieUtil(Collections.<String, String>emptyMap()));
+    curieUtil = new CurieUtil(Collections.<String, String>emptyMap());
+    cypherUtil = new CypherUtil(graphDb, curieUtil);
   }
 
   @AfterClass

--- a/SciGraph-services/src/main/java/io/scigraph/services/jersey/dynamic/CypherInflector.java
+++ b/SciGraph-services/src/main/java/io/scigraph/services/jersey/dynamic/CypherInflector.java
@@ -16,6 +16,8 @@
 package io.scigraph.services.jersey.dynamic;
 
 import static com.google.common.collect.Iterables.getFirst;
+
+import com.tinkerpop.blueprints.Graph;
 import io.scigraph.internal.CypherUtil;
 import io.scigraph.internal.GraphAspect;
 import io.scigraph.internal.TinkerGraphUtil;
@@ -77,7 +79,9 @@ class CypherInflector implements Inflector<ContainerRequestContext, Response> {
       Result result = cypherUtil.execute(config.getQuery(), paramMap);
       logger.fine((System.currentTimeMillis() - start) + " to execute query" );
       start = System.currentTimeMillis();
-      TinkerGraph graph = TinkerGraphUtil.resultToGraph(result);
+      TinkerGraphUtil tgu = new TinkerGraphUtil(curieUtil);
+      Graph graph = tgu.resultToGraph(result);
+      tgu.setGraph(graph);
       logger.fine((System.currentTimeMillis() - start) + " to convert to graph" );
       start = System.currentTimeMillis();
       for (String key: aspectMap.keySet()) {
@@ -88,7 +92,7 @@ class CypherInflector implements Inflector<ContainerRequestContext, Response> {
       if (paramMap.containsKey("project")) {
         @SuppressWarnings("unchecked")
         Collection<String> projection = (Collection<String>)(Collection<?>)paramMap.get("project");
-        TinkerGraphUtil.project(graph, projection);
+        tgu.project(projection);
       }
       ArrayPropertyTransformer.transform(graph);
       tx.success();

--- a/SciGraph-services/src/main/java/io/scigraph/services/resources/GraphService.java
+++ b/SciGraph-services/src/main/java/io/scigraph/services/resources/GraphService.java
@@ -176,7 +176,8 @@ public class GraphService extends BaseResource {
       tg = api.getNeighbors(newHashSet(nodes), depth.get(), types, nodePredicate);
       tx.success();
     }
-    TinkerGraphUtil.project(tg, projection);
+    TinkerGraphUtil tgu = new TinkerGraphUtil(tg, curieUtil);
+    tgu.project(projection);
     ArrayPropertyTransformer.transform(tg);
     GenericEntity<Graph> response = new GenericEntity<Graph>(tg) {};
     return JaxRsUtil.wrapJsonp(request.get(), response, callback);


### PR DESCRIPTION
This commit changes TinkerGraphUtil from a static class to a normal class, and requires a CurieUtil instance to be passed in to instantiate TinkerGraphUtil. Mostly a lot of plumbing fixes in order to route the instantiated TinkerGraphUtil through function calls, etc.

Fixes #152.