### PR TITLE
[#219] Update dropwizard version

### DIFF
--- a/SciGraph-services/pom.xml
+++ b/SciGraph-services/pom.xml
@@ -24,7 +24,15 @@
   </parent>
   <artifactId>scigraph-services</artifactId>
   <name>SciGraph - services</name>
-
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.glassfish.hk2</groupId>
+        <artifactId>hk2-api</artifactId>
+        <version>2.5.0-b32</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>io.dropwizard</groupId>
@@ -158,7 +166,7 @@
     <dependency>
       <groupId>ru.vyarus</groupId>
       <artifactId>dropwizard-guicey</artifactId>
-      <version>3.0.1</version>
+      <version>4.0.1</version>
     </dependency>
     
     <dependency>

--- a/SciGraph-services/src/main/java/io/scigraph/services/auth/BasicAuthenticator.java
+++ b/SciGraph-services/src/main/java/io/scigraph/services/auth/BasicAuthenticator.java
@@ -25,28 +25,42 @@ import org.apache.shiro.authc.UnknownAccountException;
 import org.apache.shiro.authc.UsernamePasswordToken;
 import org.apache.shiro.subject.Subject;
 
-import com.google.common.base.Optional;
+import java.security.Principal;
+import java.util.Optional;
 
 import io.dropwizard.auth.AuthenticationException;
 import io.dropwizard.auth.Authenticator;
 import io.dropwizard.auth.basic.BasicCredentials;
 
-public class BasicAuthenticator implements Authenticator<BasicCredentials, Subject> {
+public class BasicAuthenticator implements Authenticator<BasicCredentials, Principal> {
 
   private static final Logger logger = Logger.getLogger(BasicAuthenticator.class.getName());
   
   @Override
-  public Optional<Subject> authenticate(BasicCredentials credentials) throws AuthenticationException {
+  public java.util.Optional<Principal> authenticate(BasicCredentials credentials) throws AuthenticationException {
     Subject subject = SecurityUtils.getSubject();
     try {
       subject.login(new UsernamePasswordToken(credentials.getUsername(), credentials.getPassword(), false));
-      return Optional.of(subject);
+      User user = new User(subject);
+      return Optional.of(user);
     } catch (UnknownAccountException | IncorrectCredentialsException | LockedAccountException e) {
       logger.log(Level.WARNING, e.getMessage(), e);
     } catch (org.apache.shiro.authc.AuthenticationException ae) {
       logger.log(Level.WARNING, ae.getMessage(), ae);
     }
-    return Optional.absent();
+    return Optional.empty();
   }
 
+  public static class User implements Principal {
+	    private final Subject subject;
+	    public User(Subject subject) {
+	        this.subject = subject;
+	    }
+	    public String getName() {
+	        return subject.getPrincipal().toString();
+	    }
+	    public Subject getSubject() {
+	        return subject;
+	    }
+	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <dropwizard.version>0.8.1</dropwizard.version>
+    <dropwizard.version>1.1.0</dropwizard.version>
     <guice.version>4.0</guice.version>
     <blueprints.version>2.6.0</blueprints.version>
     <neo4j.version>3.0.7</neo4j.version>


### PR DESCRIPTION
This pull request updates dropwizard to version 1.1.0. 

I had to add hk2-api version 2.5.0-b32 to the dependencyManagement section of the pom.xml because the latest version of dropwizard-guicey pulls in hk2-api version 2.5.0-b05 which causes runtime classpath issues.

I also had to make some changes to the BasicAuthenticator module because apache shiro changed its Authenticator API to use java.util.Optional instead of guava's Optional. Also, the authenticate method now returns a java.util.Principal instead of an apache shiro Subject, so I had to write a wrapper class to extend Principal that returns the information from a Subject.