### PR TITLE
Get versionIRI, annotation axioms applied to ontology IRI

### DIFF
--- a/SciGraph-core/src/main/java/io/scigraph/owlapi/GraphOwlVisitor.java
+++ b/SciGraph-core/src/main/java/io/scigraph/owlapi/GraphOwlVisitor.java
@@ -119,7 +119,7 @@ public class GraphOwlVisitor extends OWLOntologyWalkerVisitor<Void> {
   public Void visit(OWLOntology ontology) {
     this.ontology = Optional.of(ontology);
     this.definingOntology = OwlApiUtils.getIri(ontology);
-    Long VersionNodeID = null;
+    Long versionNodeID = null;
     Long ontologyNodeID = null;
     OWLOntologyID id = ontology.getOntologyID();
     if (null == id.getOntologyIRI()) {
@@ -128,10 +128,10 @@ public class GraphOwlVisitor extends OWLOntologyWalkerVisitor<Void> {
       ontologyNodeID = getOrCreateNode(id.getOntologyIRI().toString(), OwlLabels.OWL_ONTOLOGY);
     }
     if (null != id.getVersionIRI()){
-       VersionNodeID = getOrCreateNode(id.getVersionIRI().toString(), OwlLabels.OWL_ONTOLOGY);
+      versionNodeID = getOrCreateNode(id.getVersionIRI().toString(), OwlLabels.OWL_ONTOLOGY);
     }
-    if (null != ontologyNodeID && null != VersionNodeID) {
-        graph.createRelationship(ontologyNodeID, VersionNodeID, OwlRelationships.OWL_VERSION_IRI);
+    if (null != ontologyNodeID && null != versionNodeID) {
+      graph.createRelationship(ontologyNodeID, versionNodeID, OwlRelationships.OWL_VERSION_IRI);
     }
     return null;
   }

--- a/SciGraph-core/src/main/java/io/scigraph/owlapi/GraphOwlVisitor.java
+++ b/SciGraph-core/src/main/java/io/scigraph/owlapi/GraphOwlVisitor.java
@@ -127,9 +127,7 @@ public class GraphOwlVisitor extends OWLOntologyWalkerVisitor<Void> {
     } else {
       ontologyNodeID = getOrCreateNode(id.getOntologyIRI().toString(), OwlLabels.OWL_ONTOLOGY);
     }
-    if (null == id.getVersionIRI()){
-        
-    } else {
+    if (null != id.getVersionIRI()){
        VersionNodeID = getOrCreateNode(id.getVersionIRI().toString(), OwlLabels.OWL_ONTOLOGY);
     }
     if (null != ontologyNodeID && null != VersionNodeID) {

--- a/SciGraph-core/src/main/java/io/scigraph/owlapi/GraphOwlVisitor.java
+++ b/SciGraph-core/src/main/java/io/scigraph/owlapi/GraphOwlVisitor.java
@@ -119,11 +119,21 @@ public class GraphOwlVisitor extends OWLOntologyWalkerVisitor<Void> {
   public Void visit(OWLOntology ontology) {
     this.ontology = Optional.of(ontology);
     this.definingOntology = OwlApiUtils.getIri(ontology);
+    Long VersionNodeID = null;
+    Long ontologyNodeID = null;
     OWLOntologyID id = ontology.getOntologyID();
     if (null == id.getOntologyIRI()) {
       logger.fine("Ignoring null ontology ID for " + ontology.toString());
     } else {
-      getOrCreateNode(id.getOntologyIRI().toString(), OwlLabels.OWL_ONTOLOGY);
+      ontologyNodeID = getOrCreateNode(id.getOntologyIRI().toString(), OwlLabels.OWL_ONTOLOGY);
+    }
+    if (null == id.getVersionIRI()){
+        
+    } else {
+       VersionNodeID = getOrCreateNode(id.getVersionIRI().toString(), OwlLabels.OWL_ONTOLOGY);
+    }
+    if (null != ontologyNodeID && null != VersionNodeID) {
+        graph.createRelationship(ontologyNodeID, VersionNodeID, OwlRelationships.OWL_VERSION_IRI);
     }
     return null;
   }

--- a/SciGraph-core/src/main/java/io/scigraph/owlapi/OwlRelationships.java
+++ b/SciGraph-core/src/main/java/io/scigraph/owlapi/OwlRelationships.java
@@ -57,6 +57,9 @@ public class OwlRelationships {
   
   public static final RelationshipType RDFS_IS_DEFINED_BY = RelationshipType
       .withName(getNeo4jName(OWLRDFVocabulary.RDFS_IS_DEFINED_BY));
+  
+  public static final RelationshipType OWL_VERSION_IRI = RelationshipType
+          .withName(getNeo4jName(OWLRDFVocabulary.OWL_VERSION_IRI));
 
   public static final RelationshipType FILLER = RelationshipType.withName("filler");
 

--- a/SciGraph-core/src/main/java/io/scigraph/owlapi/loader/OwlOntologyProducer.java
+++ b/SciGraph-core/src/main/java/io/scigraph/owlapi/loader/OwlOntologyProducer.java
@@ -22,7 +22,10 @@ import io.scigraph.owlapi.OwlRelationships;
 import io.scigraph.owlapi.ReasonerUtil;
 import io.scigraph.owlapi.loader.OwlLoadConfiguration.OntologySetup;
 import io.scigraph.owlapi.loader.bindings.IndicatesNumberOfShutdownProducers;
+import uk.ac.manchester.cs.owl.owlapi.OWLAnnotationAssertionAxiomImpl;
+import org.semanticweb.owlapi.model.OWLAnnotationSubject;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
@@ -33,6 +36,9 @@ import java.util.logging.Logger;
 
 import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLAnnotation;
+import org.semanticweb.owlapi.model.OWLAnnotationAssertionAxiom;
+import org.semanticweb.owlapi.model.OWLAnnotationSubject;
 import org.semanticweb.owlapi.model.OWLImportsDeclaration;
 import org.semanticweb.owlapi.model.OWLObject;
 import org.semanticweb.owlapi.model.OWLOntology;
@@ -81,6 +87,7 @@ final class OwlOntologyProducer implements Callable<Long> {
     long objectCount = 0;
     for (OWLOntology ontology : manager.getOntologies()) {
       String ontologyIri = OwlApiUtils.getIri(ontology);
+      queue.put(new OWLCompositeObject(ontologyIri, ontology));
 
       for (OWLObject object : ontology.getNestedClassExpressions()) {
         queue.put(new OWLCompositeObject(ontologyIri, object));
@@ -90,9 +97,20 @@ final class OwlOntologyProducer implements Callable<Long> {
         queue.put(new OWLCompositeObject(ontologyIri, object));
         objectCount++;
       }
+            
       for (OWLObject object : ontology.getAxioms()) { // only in the current ontology
-        queue.put(new OWLCompositeObject(ontologyIri, object));
-        objectCount++;
+          queue.put(new OWLCompositeObject(ontologyIri, object));
+          objectCount++;
+        }
+      
+      for (OWLAnnotation annotation : ontology.getAnnotations()) { // Get annotations on ontology iri
+          OWLAnnotationSubject ontologySubject = IRI.create(ontologyIri);
+          OWLAnnotationAssertionAxiom object = 
+                  new OWLAnnotationAssertionAxiomImpl(ontologySubject,
+                          annotation.getProperty(), annotation.getValue(),
+                          new ArrayList<OWLAnnotation>());
+          queue.put(new OWLCompositeObject(ontologyIri, object));
+          objectCount++;
       }
     }
     Thread.currentThread().setName(origThreadName);

--- a/SciGraph-core/src/main/java/io/scigraph/owlapi/loader/OwlOntologyProducer.java
+++ b/SciGraph-core/src/main/java/io/scigraph/owlapi/loader/OwlOntologyProducer.java
@@ -38,7 +38,6 @@ import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLAnnotation;
 import org.semanticweb.owlapi.model.OWLAnnotationAssertionAxiom;
-import org.semanticweb.owlapi.model.OWLAnnotationSubject;
 import org.semanticweb.owlapi.model.OWLImportsDeclaration;
 import org.semanticweb.owlapi.model.OWLObject;
 import org.semanticweb.owlapi.model.OWLOntology;
@@ -99,18 +98,18 @@ final class OwlOntologyProducer implements Callable<Long> {
       }
             
       for (OWLObject object : ontology.getAxioms()) { // only in the current ontology
-          queue.put(new OWLCompositeObject(ontologyIri, object));
-          objectCount++;
-        }
+        queue.put(new OWLCompositeObject(ontologyIri, object));
+        objectCount++;
+      }
       
       for (OWLAnnotation annotation : ontology.getAnnotations()) { // Get annotations on ontology iri
-          OWLAnnotationSubject ontologySubject = IRI.create(ontologyIri);
-          OWLAnnotationAssertionAxiom object = 
-                  new OWLAnnotationAssertionAxiomImpl(ontologySubject,
-                          annotation.getProperty(), annotation.getValue(),
-                          new ArrayList<OWLAnnotation>());
-          queue.put(new OWLCompositeObject(ontologyIri, object));
-          objectCount++;
+        OWLAnnotationSubject ontologySubject = IRI.create(ontologyIri);
+        OWLAnnotationAssertionAxiom object = 
+                new OWLAnnotationAssertionAxiomImpl(ontologySubject,
+                        annotation.getProperty(), annotation.getValue(),
+                        new ArrayList<OWLAnnotation>());
+        queue.put(new OWLCompositeObject(ontologyIri, object));
+        objectCount++;
       }
     }
     Thread.currentThread().setName(origThreadName);

--- a/SciGraph-core/src/test/resources/ontologies/family.owl
+++ b/SciGraph-core/src/test/resources/ontologies/family.owl
@@ -6,9 +6,14 @@
  <Ontology
    xml:base="http://example.com/owl/families/"
    ontologyIRI="http://example.com/owl/families"
+   versionIRI="http://example.com/owl/families/2017-10-05/family.owl"
    xmlns="http://www.w3.org/2002/07/owl#">
    <Prefix name="owl" IRI="http://www.w3.org/2002/07/owl#"/>
    <Prefix name="otherOnt" IRI="http://example.org/otherOntologies/families/"/>
+   <Annotation>
+     <AnnotationProperty abbreviatedIRI="owl:versionInfo"/>
+     <Literal>version 4.0</Literal>
+   </Annotation>
 
    <Declaration>
      <NamedIndividual IRI="John"/>


### PR DESCRIPTION
Currently versionIRI and all annotation axioms on an ontology IRI are not added to the Neo4J graph.  See https://github.com/monarch-initiative/SciGraph-docker-monarch-data/issues/3 as a background.

- [x] Fix ontology annotation, versionIRI issue
- [x] Write new tests