### PR TITLE
Incorporating bolt connector

### DIFF
--- a/SciGraph-core/src/main/java/io/scigraph/neo4j/Neo4jModule.java
+++ b/SciGraph-core/src/main/java/io/scigraph/neo4j/Neo4jModule.java
@@ -147,8 +147,12 @@ public class Neo4jModule extends AbstractModule {
   @Singleton
   GraphDatabaseService getGraphDatabaseService() throws IOException {
     try {
+      GraphDatabaseSettings.BoltConnector bolt = GraphDatabaseSettings.boltConnector( "0" );
       GraphDatabaseBuilder graphDatabaseBuilder = new GraphDatabaseFactory()
           .newEmbeddedDatabaseBuilder(new File(configuration.getLocation()))
+          .setConfig( bolt.type, "BOLT" )
+          .setConfig( bolt.enabled, "true" )
+          .setConfig( bolt.address, "localhost:7688" )
           .setConfig(configuration.getNeo4jConfig());
       if (readOnly) {
         graphDatabaseBuilder.setConfig(GraphDatabaseSettings.read_only, Settings.TRUE);

--- a/SciGraph-core/src/main/java/io/scigraph/neo4j/Neo4jModule.java
+++ b/SciGraph-core/src/main/java/io/scigraph/neo4j/Neo4jModule.java
@@ -152,7 +152,7 @@ public class Neo4jModule extends AbstractModule {
           .newEmbeddedDatabaseBuilder(new File(configuration.getLocation()))
           .setConfig( bolt.type, "BOLT" )
           .setConfig( bolt.enabled, "true" )
-          .setConfig( bolt.address, "localhost:7688" )
+          .setConfig( bolt.address, "0.0.0.0:7688" )
           .setConfig(configuration.getNeo4jConfig());
       if (readOnly) {
         graphDatabaseBuilder.setConfig(GraphDatabaseSettings.read_only, Settings.TRUE);

--- a/pom.xml
+++ b/pom.xml
@@ -259,6 +259,11 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-bolt</artifactId>
+      <version>3.2.1</version>
+    </dependency>
   </dependencies>
 
   <reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -264,6 +264,11 @@
       <artifactId>neo4j-bolt</artifactId>
       <version>3.2.1</version>
     </dependency>
+    <dependency>
+      <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-bolt</artifactId>
+      <version>3.0.7</version>
+    </dependency>
   </dependencies>
 
   <reporting>


### PR DESCRIPTION
This PR incorporates a bolt connector into the embedded neo4j instance of Scigraph.  This will allow the browser of a standalone neo4j installation to access the embedded neo4j instance, giving the user the ability to use the browser to query and visualize Scigraph ontologies.

