### PR TITLE
refactor resolveStartQuery to expand IRIs in MATCH clauses

### DIFF
--- a/SciGraph-core/src/main/java/io/scigraph/internal/CypherUtil.java
+++ b/SciGraph-core/src/main/java/io/scigraph/internal/CypherUtil.java
@@ -148,15 +148,16 @@ public class CypherUtil {
   /**
    * 
    * @param cypher
-   * @return cypher with resolved STARTs
+   * @return cypher with resolved Node IRIs
    * 
-   *         Resolves CURIEs to full IRIs in the section between a START and a MATCH. e.g. from
-   *         START n = node:node_auto_index(iri='DOID:4') match (n) return n to START n =
-   *         node:node_auto_index(iri='http://purl.obolibrary.org/obo/DOID_4') match (n) return n
+   *         Resolves CURIEs to full IRIs in MATCH clauses. e.g. from
+   *         MATCH (p:Node{iri:'pizza:FourSeasons'}) RETURN p to
+   *         MATCH (p:Node{iri:'http://www.co-ode.org/ontologies/pizza/
+   *         pizza.owl#FourSeasons'}) RETURN p
    */
-  public String resolveStartQuery(String cypher) {
+  public String resolveNodeIris(String cypher) {
     String resolvedCypher = cypher;
-    Pattern p = Pattern.compile("\\(\\s*iri\\s*=\\s*['|\"]([\\w:/\\?=]+)['|\"]\\s*\\)");
+    Pattern p = Pattern.compile("\\{\\s*iri\\s*:\\s*['|\"]([\\w:/\\?=]+)['|\"]\\s*\\}");
     Matcher m = p.matcher(cypher);
     while (m.find()) {
       String curie = m.group(1);

--- a/SciGraph-core/src/main/java/io/scigraph/internal/CypherUtil.java
+++ b/SciGraph-core/src/main/java/io/scigraph/internal/CypherUtil.java
@@ -146,6 +146,29 @@ public class CypherUtil {
   }
 
   /**
+   *
+   * @param cypher
+   * @return cypher with resolved STARTs
+   *
+   *         Resolves CURIEs to full IRIs in the section between a START and a MATCH. e.g. from
+   *         START n = node:node_auto_index(iri='DOID:4') match (n) return n to START n =
+   *         node:node_auto_index(iri='http://purl.obolibrary.org/obo/DOID_4') match (n) return n
+   */
+  @Deprecated
+  public String resolveStartQuery(String cypher) {
+    String resolvedCypher = cypher;
+    Pattern p = Pattern.compile("\\(\\s*iri\\s*=\\s*['|\"]([\\w:/\\?=]+)['|\"]\\s*\\)");
+    Matcher m = p.matcher(cypher);
+    while (m.find()) {
+      String curie = m.group(1);
+      String iri = curieUtil.getIri(curie).orElse(curie);
+      resolvedCypher = resolvedCypher.replace(curie, iri);
+    }
+
+    return resolvedCypher;
+  }
+
+  /**
    * 
    * @param cypher
    * @return cypher with resolved Node IRIs

--- a/SciGraph-core/src/test/java/io/scigraph/internal/CypherUtilTest.java
+++ b/SciGraph-core/src/test/java/io/scigraph/internal/CypherUtilTest.java
@@ -190,36 +190,46 @@ public class CypherUtilTest extends GraphTestBase {
   }
 
   @Test
-  public void resolveStartQueryWithSingleMatch() {
-    String cypher = "START n = node:node_auto_index(iri='FOO:foo') match (n) return n";
-    assertThat(util.resolveStartQuery(cypher),
+  public void resolveMatchQueryWithSingleMatch() {
+    String cypher = "MATCH (n{iri:'FOO:foo'}) RETURN n";
+    assertThat(util.resolveNodeIris(cypher),
         IsEqual
-            .equalTo("START n = node:node_auto_index(iri='http://x.org/#foo') match (n) return n"));
+            .equalTo("MATCH (n{iri:'http://x.org/#foo'}) RETURN n"));
   }
 
   @Test
-  public void resolveStartQueryWithMultipleMatches() {
+  public void resolveMatchQueryWithMultipleNodes() {
     String cypher =
-        "START n = node:node_auto_index(iri='FOO:foo') match (n) UNION START m = node:node_auto_index(iri='FOO:fizz') match (m) return n,m";
+        "MATCH (n{iri:'FOO:foo'})-[]-(m{iri:'FOO:fizz'}) RETURN n,m";
     assertThat(
-        util.resolveStartQuery(cypher),
+        util.resolveNodeIris(cypher),
         IsEqual
-            .equalTo("START n = node:node_auto_index(iri='http://x.org/#foo') match (n) UNION START m = node:node_auto_index(iri='http://x.org/#fizz') match (m) return n,m"));
+            .equalTo("MATCH (n{iri:'http://x.org/#foo'})-[]-(m{iri:'http://x.org/#fizz'}) RETURN n,m"));
   }
 
   @Test
-  public void notResolveStartQueryWithIris() {
+  public void resolveMatchQueryWithMultipleMatches() {
     String cypher =
-        "START n = node:node_auto_index(iri='http://x.org/#foo') match (n) UNION START m = node:node_auto_index(iri='http://x.org/#fizz') match (m) return n,m";
+        "MATCH (n{iri:'FOO:foo'}) MATCH (m{iri:'FOO:fizz'}) RETURN n,m";
     assertThat(
-        util.resolveStartQuery(cypher),
+        util.resolveNodeIris(cypher),
         IsEqual
-            .equalTo("START n = node:node_auto_index(iri='http://x.org/#foo') match (n) UNION START m = node:node_auto_index(iri='http://x.org/#fizz') match (m) return n,m"));
+            .equalTo("MATCH (n{iri:'http://x.org/#foo'}) MATCH (m{iri:'http://x.org/#fizz'}) RETURN n,m"));
+  }
+
+  @Test
+  public void notResolveMatchQueryWithIris() {
+    String cypher =
+        "MATCH (n{iri:'http://x.org/#foo'})-[]-(m{iri:'http://x.org/#fizz'}) RETURN n,m";
+    assertThat(
+        util.resolveNodeIris(cypher),
+        IsEqual
+            .equalTo("MATCH (n{iri:'http://x.org/#foo'})-[]-(m{iri:'http://x.org/#fizz'}) RETURN n,m"));
   }
 
   @Test
   public void unalterRandomString() {
     String cypher = "foo";
-    assertThat(util.resolveStartQuery(cypher), IsEqual.equalTo("foo"));
+    assertThat(util.resolveNodeIris(cypher), IsEqual.equalTo("foo"));
   }
 }

--- a/SciGraph-services/src/main/java/io/scigraph/services/resources/CypherUtilService.java
+++ b/SciGraph-services/src/main/java/io/scigraph/services/resources/CypherUtilService.java
@@ -82,7 +82,7 @@ public class CypherUtilService extends BaseResource {
       notes = "Resolves curies and relationships.")
   public String resolve(
       @ApiParam(value = "The cypher query to resolve", required = true) @QueryParam("cypherQuery") String cypherQuery) {
-    return cypherUtil.resolveRelationships(cypherUtil.resolveStartQuery(cypherQuery));
+    return cypherUtil.resolveRelationships(cypherUtil.resolveNodeIris(cypherQuery));
   }
 
 
@@ -115,7 +115,7 @@ public class CypherUtilService extends BaseResource {
 
 
     String sanitizedCypherQuery = cypherQuery.replaceAll(";", "") + " LIMIT " + limit;
-    String replacedStartCurie = cypherUtil.resolveStartQuery(sanitizedCypherQuery);
+    String replacedStartCurie = cypherUtil.resolveNodeIris(sanitizedCypherQuery);
 
     // TODO I didn't find a way to time out a single query in 3.0. However it becomes easier in 3.1
 //    Guard guard =

--- a/SciGraph-services/src/test/java/io/scigraph/services/resources/CypherUtilServiceTest.java
+++ b/SciGraph-services/src/test/java/io/scigraph/services/resources/CypherUtilServiceTest.java
@@ -45,7 +45,7 @@ public class CypherUtilServiceTest {
   @Before
   public void setup() {
     when(cypherUtil.resolveRelationships("foo!")).thenReturn("foo");
-    when(cypherUtil.resolveStartQuery("foo!")).thenReturn("foo!");
+    when(cypherUtil.resolveNodeIris("foo!")).thenReturn("foo!");
   }
 
   @Test


### PR DESCRIPTION
This PR adds a new function resolveNodeIris to resolve IRIs in MATCH clauses, for example:

    MATCH (p:Node{iri:'pizza:FourSeasons'}) RETURN p 
is resolved to:

    MATCH (p:Node{iri:'http://www.co-ode.org/ontologies/pizza/pizza.owl#FourSeasons'}) RETURN p

It replaces resolveStartQuery, which is now deprecated in the scigraph-core:
See https://neo4j.com/docs/developer-manual/current/cypher/clauses/start/