### PR TITLE
Add association_has_predicate to evidence graph

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 before_install:
   - "export DISPLAY=:99.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,11 @@ language: java
 jdk:
   - openjdk8
 
+services:
+  - xvfb
+
 before_install:
   - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
 
 after_success:
   - mvn test cobertura:cobertura coveralls:report

--- a/SciGraph-core/src/main/java/io/scigraph/internal/EvidenceAspect.java
+++ b/SciGraph-core/src/main/java/io/scigraph/internal/EvidenceAspect.java
@@ -86,7 +86,8 @@ public class EvidenceAspect implements GraphAspect {
                   association.getRelationships(HAS_PREDICATE, Direction.OUTGOING).iterator();
               if (objectProperty.hasNext()) {
                 // an association has to have 1 and only 1 object property
-                Node relationshipNode = objectProperty.next().getOtherNode(association);
+                Relationship hasPredicate = objectProperty.next();
+                Node relationshipNode = hasPredicate.getOtherNode(association);
                 String objectPropertyRelationship =
                     GraphUtil.getProperty(relationshipNode, NodeProperties.IRI, String.class).get();
 
@@ -107,6 +108,7 @@ public class EvidenceAspect implements GraphAspect {
                                      // object
                   TinkerGraphUtil tgu = new TinkerGraphUtil(graph, curieUtil);
                   tgu.addEdge(hasSubject);
+                  tgu.addEdge(hasPredicate);
                   tgu.addEdge(hasObject);
                   for (Relationship evidence : association.getRelationships(EVIDENCE,
                       Direction.OUTGOING)) {

--- a/SciGraph-core/src/test/java/io/scigraph/internal/EvidenceAspectTest.java
+++ b/SciGraph-core/src/test/java/io/scigraph/internal/EvidenceAspectTest.java
@@ -80,7 +80,7 @@ public class EvidenceAspectTest extends GraphTestBase {
     assertThat(graph.getEdges(), IsIterableWithSize.<Edge>iterableWithSize(1));
     aspect.invoke(graph);
     assertThat(graph.getVertices(), IsIterableWithSize.<Vertex>iterableWithSize(6));
-    assertThat(graph.getEdges(), IsIterableWithSize.<Edge>iterableWithSize(3));
+    assertThat(graph.getEdges(), IsIterableWithSize.<Edge>iterableWithSize(4));
   }
 
 


### PR DESCRIPTION
This is a small patch that adds association_has_predicate relationships to evidence graphs created in the EvidenceAspect class 