### PR TITLE
Make EntityProcessorImpl and its getAnnotations() method public

### DIFF
--- a/SciGraph-entity/src/main/java/io/scigraph/annotation/EntityProcessorImpl.java
+++ b/SciGraph-entity/src/main/java/io/scigraph/annotation/EntityProcessorImpl.java
@@ -60,7 +60,7 @@ import com.google.common.collect.ForwardingMap;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.PeekingIterator;
 
-class EntityProcessorImpl implements EntityProcessor {
+public class EntityProcessorImpl implements EntityProcessor {
 
   private static final Logger logger = Logger.getLogger(EntityProcessorImpl.class.getName());
 
@@ -68,7 +68,7 @@ class EntityProcessorImpl implements EntityProcessor {
   private final EntityRecognizer recognizer;
 
   @Inject
-  protected EntityProcessorImpl(EntityRecognizer recognizer) {
+  public EntityProcessorImpl(EntityRecognizer recognizer) {
     this.recognizer = recognizer;
     analyzer = new EntityAnalyzer();
   }

--- a/SciGraph-entity/src/main/java/io/scigraph/annotation/EntityProcessorImpl.java
+++ b/SciGraph-entity/src/main/java/io/scigraph/annotation/EntityProcessorImpl.java
@@ -90,6 +90,18 @@ public class EntityProcessorImpl implements EntityProcessor {
     }));
   }
 
+  /**
+   * Returns a list of annotations found in the provided text.
+   *
+   * @param content The text to search for annotations. This is used as a Lucene query, so any
+   *                characters that may be used by a Lucene query should be commented out. This
+   *                can be done by using <a href="https://lucene.apache.org/core/6_6_2/queryparser/org/apache/lucene/queryparser/classic/QueryParserBase.html#escape-java.lang.String-"
+   *                ><tt>QueryParserBase.escape()</tt></a>.
+   * @param config Configuration options for entity annotation. Some fields (reader, writer) are ignored,
+   *               but config.isLongestOnly() is used.
+   * @return A list of entity annotations found in this text.
+   * @throws InterruptedException Thrown if the Shingle Producer Thread created by startShingleProducer is interrupted.
+   */
   public List<EntityAnnotation> getAnnotations(String content, EntityFormatConfiguration config)
       throws InterruptedException {
     checkNotNull(content);
@@ -271,6 +283,14 @@ public class EntityProcessorImpl implements EntityProcessor {
     return shouldAnnotate;
   }
 
+  /**
+   * Returns a list of annotations found in the provided HTML text.
+   *
+   * @param config Configuration options for entity annotation. The HTML text to be annotated is read from the <tt>reader</tt>
+   *               variable, and annotated text is written out to the Writer in the <tt>writer</tt> variable.
+   * @return A list of entity annotations found in this text.
+   * @throws IOException Thrown if there in an error in reading the text.
+   */
   @Override
   public List<EntityAnnotation> annotateEntities(EntityFormatConfiguration config)
       throws IOException {

--- a/SciGraph-entity/src/main/java/io/scigraph/annotation/EntityProcessorImpl.java
+++ b/SciGraph-entity/src/main/java/io/scigraph/annotation/EntityProcessorImpl.java
@@ -90,7 +90,7 @@ public class EntityProcessorImpl implements EntityProcessor {
     }));
   }
 
-  protected List<EntityAnnotation> getAnnotations(String content, EntityFormatConfiguration config)
+  public List<EntityAnnotation> getAnnotations(String content, EntityFormatConfiguration config)
       throws InterruptedException {
     checkNotNull(content);
     BlockingQueue<List<Token<String>>> queue = startShingleProducer(content);

--- a/SciGraph-entity/src/main/java/io/scigraph/annotation/EntityRecognizer.java
+++ b/SciGraph-entity/src/main/java/io/scigraph/annotation/EntityRecognizer.java
@@ -39,7 +39,7 @@ public class EntityRecognizer {
   private final CurieUtil curieUtil;
 
   @Inject
-  EntityRecognizer(Vocabulary vocabulary, CurieUtil curieUtil) throws IOException {
+  public EntityRecognizer(Vocabulary vocabulary, CurieUtil curieUtil) throws IOException {
     this.vocabulary = vocabulary;
     this.curieUtil = curieUtil;
   }

--- a/SciGraph-entity/src/test/java/io/scigraph/annotation/EntityProcessorImplTest.java
+++ b/SciGraph-entity/src/test/java/io/scigraph/annotation/EntityProcessorImplTest.java
@@ -34,6 +34,7 @@ import io.scigraph.annotation.EntityRecognizer;
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.io.StringWriter;
 import java.io.Writer;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -86,8 +87,9 @@ public class EntityProcessorImplTest {
 
   @Test
   public void testAnnotateEntities() throws IOException, InterruptedException {
+    StringWriter annotatedOutput = new StringWriter();
+    when(config.getWriter()).thenReturn(annotatedOutput);
     when(config.getReader()).thenReturn(new StringReader(text));
-    when(config.getWriter()).thenReturn(Writer.nullWriter());
     List<EntityAnnotation> annotations = processor.annotateEntities(config);
     assertThat(annotations, equalTo(expectedAnnotations));
   }

--- a/SciGraph-entity/src/test/java/io/scigraph/annotation/EntityProcessorImplTest.java
+++ b/SciGraph-entity/src/test/java/io/scigraph/annotation/EntityProcessorImplTest.java
@@ -33,6 +33,8 @@ import io.scigraph.annotation.EntityProcessorImpl;
 import io.scigraph.annotation.EntityRecognizer;
 
 import java.io.IOException;
+import java.io.StringReader;
+import java.io.Writer;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -79,6 +81,14 @@ public class EntityProcessorImplTest {
   @Test
   public void testGetAnnotations() throws IOException, InterruptedException {
     List<EntityAnnotation> annotations = processor.getAnnotations(text, config);
+    assertThat(annotations, equalTo(expectedAnnotations));
+  }
+
+  @Test
+  public void testAnnotateEntities() throws IOException, InterruptedException {
+    when(config.getReader()).thenReturn(new StringReader(text));
+    when(config.getWriter()).thenReturn(Writer.nullWriter());
+    List<EntityAnnotation> annotations = processor.annotateEntities(config);
     assertThat(annotations, equalTo(expectedAnnotations));
   }
 


### PR DESCRIPTION
This allows external programs to programmatically extract annotations from plain text documents (the current publicly accessible method, `annotateEntities()`, is designed to work on HTML content, as per https://github.com/SciGraph/SciGraph/issues/282).

WIP: Needs tests and better comments.