### PR TITLE
Make constructors and methods public for embedded use

### DIFF
--- a/SciGraph-entity/src/main/java/io/scigraph/annotation/EntityProcessorImpl.java
+++ b/SciGraph-entity/src/main/java/io/scigraph/annotation/EntityProcessorImpl.java
@@ -90,7 +90,16 @@ public class EntityProcessorImpl implements EntityProcessor {
     }));
   }
 
-  protected List<EntityAnnotation> getAnnotations(String content, EntityFormatConfiguration config)
+  /***
+   * Identify annotations within the provided text.
+   *
+   * @param content
+   *    The string to identify annotations within.
+   * @param config
+   *    Configuration settings for identifying annotations.
+   * @return A list of entity annotations from this text.
+   */
+  public List<EntityAnnotation> getAnnotations(String content, EntityFormatConfiguration config)
       throws InterruptedException {
     checkNotNull(content);
     BlockingQueue<List<Token<String>>> queue = startShingleProducer(content);

--- a/SciGraph-entity/src/main/java/io/scigraph/annotation/EntityProcessorImpl.java
+++ b/SciGraph-entity/src/main/java/io/scigraph/annotation/EntityProcessorImpl.java
@@ -60,7 +60,7 @@ import com.google.common.collect.ForwardingMap;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.PeekingIterator;
 
-class EntityProcessorImpl implements EntityProcessor {
+public class EntityProcessorImpl implements EntityProcessor {
 
   private static final Logger logger = Logger.getLogger(EntityProcessorImpl.class.getName());
 
@@ -68,7 +68,7 @@ class EntityProcessorImpl implements EntityProcessor {
   private final EntityRecognizer recognizer;
 
   @Inject
-  protected EntityProcessorImpl(EntityRecognizer recognizer) {
+  public EntityProcessorImpl(EntityRecognizer recognizer) {
     this.recognizer = recognizer;
     analyzer = new EntityAnalyzer();
   }

--- a/SciGraph-entity/src/main/java/io/scigraph/annotation/EntityRecognizer.java
+++ b/SciGraph-entity/src/main/java/io/scigraph/annotation/EntityRecognizer.java
@@ -39,7 +39,7 @@ public class EntityRecognizer {
   private final CurieUtil curieUtil;
 
   @Inject
-  EntityRecognizer(Vocabulary vocabulary, CurieUtil curieUtil) throws IOException {
+  public EntityRecognizer(Vocabulary vocabulary, CurieUtil curieUtil) throws IOException {
     this.vocabulary = vocabulary;
     this.curieUtil = curieUtil;
   }


### PR DESCRIPTION
There is currently no way to use the EntityRecognizer from outside of SciGraph to look for text in arbitrary text. This PR makes to sets of changes that make that possible:
- It makes the `EntityProcessorImpl` class public, so that it can be accessed from outside the package.
- It makes its `getAnnotations()` method public, as the standard public method (`annotateEntities()`) is designed to work only on HTML text, while `getAnnotations()` is designed to work on plain text.