### PR TITLE
match the behavior of /cypher/execute to /dynamic/

### DIFF
--- a/SciGraph-services/pom.xml
+++ b/SciGraph-services/pom.xml
@@ -238,7 +238,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>2.5</version>
+        <version>3.2.0</version>
         <configuration>
           <archive>
             <manifest>

--- a/SciGraph-services/src/test/java/io/scigraph/services/resources/CypherUtilServiceTest.java
+++ b/SciGraph-services/src/test/java/io/scigraph/services/resources/CypherUtilServiceTest.java
@@ -32,15 +32,17 @@ import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.guard.Guard;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.test.TestGraphDatabaseFactory;
+import org.prefixcommons.CurieUtil;
 
 public class CypherUtilServiceTest {
 
   private static final CypherUtil cypherUtil = mock(CypherUtil.class);
   private static final GraphDatabaseService graphDb = mock(GraphDatabaseService.class);
+  private static final CurieUtil curieUtil = mock(CurieUtil.class);
 
   @ClassRule
   public static final ResourceTestRule resources = ResourceTestRule.builder()
-      .addResource(new CypherUtilService(cypherUtil, graphDb)).build();
+      .addResource(new CypherUtilService(cypherUtil, graphDb, curieUtil)).build();
 
   @Before
   public void setup() {
@@ -50,7 +52,7 @@ public class CypherUtilServiceTest {
 
   @Test
   public void smokeConstructor() {
-    new CypherUtilService(cypherUtil, graphDb);
+    new CypherUtilService(cypherUtil, graphDb, curieUtil);
   }
 
   @Test


### PR DESCRIPTION
This change makes it vastly simpler to develop dynamic cypher queries
by changing the /cypher/execute endpoint to match the preprocessing
and return types for /dynamic/ cypher queries.

Related to https://github.com/SciGraph/SciGraph/issues/287. @dbrnz 