### PR TITLE
SciGraph also needs `javax.xml.bind` to be installed.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -277,6 +277,11 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.3.1</version>
+    </dependency>
   </dependencies>
 
   <reporting>


### PR DESCRIPTION
Otherwise SciGraph doesn't start when using recent versions of Java. 